### PR TITLE
Fix for the ReDOS vulenerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jsonwebtoken": "^7.0.0",
     "kue": "latest",
     "lodash": "latest",
-    "meanio": "0.8.0",
+    "meanio": "0.9.2",
     "mongoose": "latest",
     "morgan": "latest",
     "ms": "latest",


### PR DESCRIPTION
root is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `meanio`

This PR fixes the ReDOS  vulnerability by upgrading `meanio` to version 0.9.2
The upgrade will also fix the following other vulnerabilities: 
- [ReDOS vulnerability](https://snyk.io/vuln/npm:ms:20151024) in the `ms` dependency

You are already watching this repo with Snyk, so check out [the project](https://snyk.io/test/github/linnovate/root) to review other vulnerabilities that affect this repo, and generate a PR to fix more vulnerabilities. 

Stay secure, 
The Snyk team
